### PR TITLE
サンプルスタイルを適用すると地図が表示されなくなる問題を修正

### DIFF
--- a/style/std.json
+++ b/style/std.json
@@ -9,7 +9,7 @@
 			"minzoom": 0,
 			"maxzoom": 16,
 			"tiles": [
-				"http://cyberjapandata.gsi.go.jp/xyz/experimental_bvmap-v1/{z}/{x}/{y}.pbf"
+				"https://cyberjapandata.gsi.go.jp/xyz/experimental_bvmap-v1/{z}/{x}/{y}.pbf"
 			],
 			"attribution": "国土地理院最適化ベクトルタイル(標準地図風スタイル)"
 		}


### PR DESCRIPTION
デモページで「サンプルスタイル（標準地図風）適用」をチェックしたときに、
std.json をロード後に pbf 取得がエラーになる問題が発生。
タイルの取得先が http:// になっているのが原因と思われるので https:// に修正してはどうか。